### PR TITLE
feature/route-based-google-analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11470,6 +11470,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
       "integrity": "sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw=="
     },
+    "react-ga": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.6.0.tgz",
+      "integrity": "sha512-GWHBWZDFjDGMkIk1LzroIn0mNTygKw3adXuqvGvheFZvlbpqMPbHsQsTdQBIxRRdXGQM/Zq+dQLRPKbwIHMTaw=="
+    },
     "react-highlight-words": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/react-highlight-words/-/react-highlight-words-0.16.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "query-string": "^6.8.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-ga": "^2.6.0",
     "react-highlight-words": "^0.16.0",
     "react-player": "^1.11.2",
     "react-router-dom": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -4,16 +4,6 @@
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-145893191-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-145893191-1');
-    </script>
-
     <link
       rel="stylesheet"
       href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css"

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,6 @@
 import React from "react";
+import ReactGA from "react-ga";
+import withTracker from "./utils/withTracker";
 import { HashRouter as Router, Route, Switch } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
@@ -9,16 +11,19 @@ import AllEvents from "./pages/AllEvents";
 import People from "./pages/People";
 import Person from "./pages/Person";
 
+// Run Google Analytics
+ReactGA.initialize("UA-145893191-1");
+
 const App = () => (
   <Router basename="/">
     <Header />
     <Switch>
-      <Route exact path="/" component={Home} />
-      <Route path="/search" component={Search} />
-      <Route exact path="/events" component={AllEvents} />
-      <Route path="/events/:id" component={Event} />
-      <Route exact path="/people" component={People} />
-      <Route exact path="/people/:id" component={Person} />
+      <Route exact path="/" component={withTracker(Home)} />
+      <Route path="/search" component={withTracker(Search)} />
+      <Route exact path="/events" component={withTracker(AllEvents)} />
+      <Route path="/events/:id" component={withTracker(Event)} />
+      <Route exact path="/people" component={withTracker(People)} />
+      <Route exact path="/people/:id" component={withTracker(Person)} />
     </Switch>
     <Footer />
   </Router>

--- a/src/pages/People.jsx
+++ b/src/pages/People.jsx
@@ -24,4 +24,4 @@ const People = () => {
     );
 }
 
-export default People
+export default People;

--- a/src/pages/Person.jsx
+++ b/src/pages/Person.jsx
@@ -24,4 +24,4 @@ const Person = () => {
     );
 }
 
-export default Person
+export default Person;

--- a/src/utils/withTracker.jsx
+++ b/src/utils/withTracker.jsx
@@ -3,7 +3,6 @@ import ReactGA from "react-ga";
 
 export default function withTracker(WrappedComponent, options = {}) {
   const trackPage = (page) => {
-    console.log(page);
     ReactGA.set({
       page,
       ...options

--- a/src/utils/withTracker.jsx
+++ b/src/utils/withTracker.jsx
@@ -1,0 +1,34 @@
+import React, { Component } from "react";
+import ReactGA from "react-ga";
+
+export default function withTracker(WrappedComponent, options = {}) {
+  const trackPage = (page) => {
+    console.log(page);
+    ReactGA.set({
+      page,
+      ...options
+    });
+    ReactGA.pageview(page);
+  };
+
+  const HOC = class extends Component {
+    componentDidMount() {
+      trackPage(window.location.hash.substr(1));
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const currentPage = this.props.location.pathname;
+      const nextPage = nextProps.location.pathname;
+
+      if (currentPage !== nextPage) {
+        trackPage(nextPage);
+      }
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  };
+
+  return HOC;
+}


### PR DESCRIPTION
Google Analytics was only reporting that a single page was being viewed: `/seattle/`. After some investigation, looks like `react-ga` with a wrapper around each component to apply a tracker works best. This adds that.