### PR TITLE
[GH-22] add page titles

### DIFF
--- a/src/containers/AllEvents.jsx
+++ b/src/containers/AllEvents.jsx
@@ -4,6 +4,7 @@ import moment from "moment";
 import styled from "@emotion/styled";
 import { getBasicEventById, getAllEvents } from "../api";
 import EventCardGroup from "../components/EventCardGroup";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 const FiltersSection = styled.div({
   margin: "1em 0 3em !important"
@@ -32,6 +33,7 @@ const EventCardGroupContainer = ({ query }) => {
   const [allEvents, setAllEvents] = React.useState([]);
   const [isLoading, setIsLoading] = React.useState(false);
   const [visibleEvents, setVisibleEvents] = React.useState([]);
+  useDocumentTitle('Committee Events');
 
   const handleDateFilter = (e, { value }) => {
     if (value === "all") {

--- a/src/containers/Event.jsx
+++ b/src/containers/Event.jsx
@@ -2,9 +2,12 @@ import React from "react";
 import { getEventById } from "../api";
 import { Loader } from "semantic-ui-react";
 import Event from "../components/Event";
+import useDocumentTitle from "../hooks/useDocumentTitle";
+import getDateTime from "../utils/getDateTime";
 
 const EventContainer = ({ id }) => {
   const [event, setEvent] = React.useState();
+  useDocumentTitle(event ? `${event.name} - ${getDateTime(event.date)}` : 'Loading...');
 
   React.useEffect(() => {
     try {
@@ -15,7 +18,7 @@ const EventContainer = ({ id }) => {
     } catch (e) {
       // log error and display message
     }
-  }, []);
+  }, [id]);
 
   return event ? (
     <Event

--- a/src/containers/EventCardGroup.jsx
+++ b/src/containers/EventCardGroup.jsx
@@ -4,6 +4,7 @@ import moment from "moment";
 import styled from "@emotion/styled";
 import { getEventsByIndexedTerm } from "../api";
 import EventCardGroup from "../components/EventCardGroup";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 const SearchSection = styled.div({
   margin: "1em 0 3em !important"
@@ -32,6 +33,7 @@ const EventCardGroupContainer = ({ query }) => {
   const [searchInProgress, setSearchInProgress] = React.useState(false);
   const [allEvents, setAllEvents] = React.useState([]);
   const [visibleEvents, setVisibleEvents] = React.useState([]);
+  useDocumentTitle(`${searchQuery} - Search`);
 
   const handleDateFilter = (e, { value }) => {
     if (value === "all") {

--- a/src/containers/EventCardGroup.jsx
+++ b/src/containers/EventCardGroup.jsx
@@ -33,7 +33,7 @@ const EventCardGroupContainer = ({ query }) => {
   const [searchInProgress, setSearchInProgress] = React.useState(false);
   const [allEvents, setAllEvents] = React.useState([]);
   const [visibleEvents, setVisibleEvents] = React.useState([]);
-  useDocumentTitle(`${searchQuery} - Search`);
+  useDocumentTitle(`Search - ${searchQuery}`);
 
   const handleDateFilter = (e, { value }) => {
     if (value === "all") {

--- a/src/containers/PeopleCardGroupContainer.jsx
+++ b/src/containers/PeopleCardGroupContainer.jsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { getAllPeople } from '../api'
 import PeopleCardGroup from '../components/PeopleCardGroup'
 import { Loader } from "semantic-ui-react";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 const PeopleCardGroupContainer = () => {
-    const [people, updatePeople] = useState(null)
+    const [people, updatePeople] = useState(null);
+    useDocumentTitle('City Council Members');
 
     useEffect(() => {
         async function fetchData() {

--- a/src/containers/PersonContainer.jsx
+++ b/src/containers/PersonContainer.jsx
@@ -3,10 +3,11 @@ import { withRouter } from 'react-router-dom';
 import { getVotesForPerson } from '../api';
 import Person from '../components/Person';
 import { Loader } from "semantic-ui-react";
-
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 const PersonContainer = ({ match: { params: { id }} }) => {
     const [personHistory, updatePersonHistory] = useState(null);
+    useDocumentTitle(personHistory ? personHistory.full_name : 'Loading...');
     useEffect(() => {
         async function fetchData() {
             const votes = await getVotesForPerson(id);

--- a/src/hooks/useDocumentTitle.js
+++ b/src/hooks/useDocumentTitle.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+function useDocumentTitle(title) {
+  React.useEffect(() => {
+    document.title = title;
+
+    return () => {
+      document.title = 'Council Data Project - Seattle';
+    };
+  }, [title]);
+
+}
+
+export default useDocumentTitle;


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Resolves #22 
- [x] Add page titles. The page titles are:
/events "Committee Events"
/events/id "{Body name} - {Date}"
/people "City Council Members"
/people/id "{Full name}"
/search?q=searchQuery "{searchQuery} - Search"
default title is "Council Data Project - Seattle"
- [x] Provide relevant tests for your feature or bug fix (if applicable).
- [x] Provide or update documentation for any feature added by your pull request (if applicable).
- [x] Provide a link to a staging deployment or screenshots of changes (if applicable).

Thanks for contributing!
