### PR TITLE
Minor fixes to PR #38 and [GH-41]

### DIFF
--- a/src/api/eventApi.js
+++ b/src/api/eventApi.js
@@ -163,11 +163,13 @@ export async function getEventById(id) {
 * @param {Object} dateRange The start and end dates to filter search results.
 * @param {string} dateRange.start
 * @param {string} dateRange.end 
-* @param {string[]} bodyIDs A list of committee/body ids filter search results.
+* @param {string[]} bodyIDs The list of committee/body ids to filter search results.
 * @param {Object} sort The sort by and sort order options.
 * @param {string} sort.by
 * @param {string} sort.order 
-* @return {Object[]} A list of searched events filtered by dateRange, bodyIDs, and sorted by sort.
+* @return {Object[]} The search results, where each event's date is within
+* the date range and the event's body id is in bodyIDs(if it's non-empty). The search
+* results are sorted according to the sort options.
 */
 export async function getEventsByIndexedTerm(term, dateRange = {}, bodyIDs = [], sort = {}) {
   const valueMin = 0;
@@ -202,7 +204,7 @@ export async function getEventsByIndexedTerm(term, dateRange = {}, bodyIDs = [],
         )
     );
 
-    // get only events with summed values > valueMin
+    // get only event id with summed values > valueMin
     const sortedSummedMatches = filter(summedMatchValueByEventId, ({ value }) => value > valueMin);
     let events = await Promise.all(
       sortedSummedMatches.map(({ event_id }) => db.selectRowById('event', event_id))
@@ -239,11 +241,13 @@ export async function getAllBodies() {
 * @param {Object} dateRange The start and end dates to filter events.
 * @param {string} dateRange.start
 * @param {string} dateRange.end 
-* @param {string[]} bodyIDs A list of committee/body ids to filter events.
+* @param {string[]} bodyIDs The list of committee/body ids to filter events.
 * @param {Object} sort The sort by and sort order options.
 * @param {string} sort.by
 * @param {string} sort.order 
-* @return {Object[]} A list of filtered events.
+* @return {Object[]} A list of events, where each event's date is within
+* the date range and the event's body id is in bodyIDs(if it's non-empty). The events
+* are sorted according to the sort options.
 */
 export async function getFilteredEvents(dateRange, bodyIDs, sort) {
   try {
@@ -307,10 +311,11 @@ async function getBasicEvents(events) {
 /**
 * @param {Object[]} events The list of events to filter.
 * @param {Object} dateRange The start and end dates to filter events.
-* @param {string} dateRange.start
+* @param {string} dateRange.start 
 * @param {string} dateRange.end 
-* @param {string[]} bodyIDs A list of committee/body ids to filter events.
-* @return {Object[]} A list of filtered events.
+* @param {string[]} bodyIDs The list of committee/body ids to filter events.
+* @return {Object[]} A list of events, where each event's date is within
+* date range and the event's body id is in bodyIDs(if its non-empty).
 */
 function filterEvents(events, dateRange, bodyIDs) {
   return events.filter(event => {

--- a/src/api/eventApi.js
+++ b/src/api/eventApi.js
@@ -158,7 +158,17 @@ export async function getEventById(id) {
     return Promise.reject(e);
   }
 }
-
+/**
+* @param {string} term The search term
+* @param {Object} dateRange The start and end dates to filter search results.
+* @param {string} dateRange.start
+* @param {string} dateRange.end 
+* @param {string[]} bodyIDs A list of committee/body ids filter search results.
+* @param {Object} sort The sort by and sort order options.
+* @param {string} sort.by
+* @param {string} sort.order 
+* @return {Object[]} A list of searched events filtered by dateRange, bodyIDs, and sorted by sort.
+*/
 export async function getEventsByIndexedTerm(term, dateRange = {}, bodyIDs = [], sort = {}) {
   const valueMin = 0;
   try {
@@ -192,6 +202,7 @@ export async function getEventsByIndexedTerm(term, dateRange = {}, bodyIDs = [],
         )
     );
 
+    // get only events with summed values > valueMin
     const sortedSummedMatches = filter(summedMatchValueByEventId, ({ value }) => value > valueMin);
     let events = await Promise.all(
       sortedSummedMatches.map(({ event_id }) => db.selectRowById('event', event_id))
@@ -225,10 +236,14 @@ export async function getAllBodies() {
 }
 
 /**
-* @param {Object} dateRange The start and end dates to filter events. 
-* @param {Array[]} bodyIDs A list of committee ids to filter events.
+* @param {Object} dateRange The start and end dates to filter events.
+* @param {string} dateRange.start
+* @param {string} dateRange.end 
+* @param {string[]} bodyIDs A list of committee/body ids to filter events.
 * @param {Object} sort The sort by and sort order options.
-* @return {Array[]} A list of filtered events.
+* @param {string} sort.by
+* @param {string} sort.order 
+* @return {Object[]} A list of filtered events.
 */
 export async function getFilteredEvents(dateRange, bodyIDs, sort) {
   try {
@@ -269,6 +284,10 @@ async function getFilteredEventsHelper(dateRange, bodyID = null) {
   );
 }
 
+/**
+* @param {Object[]} events The list of events
+* @return {Object[]} The formatted list of events with basic information for front-end.
+*/
 async function getBasicEvents(events) {
   const allBodies = await getAllBodies();
   return events.map(event => {
@@ -286,10 +305,12 @@ async function getBasicEvents(events) {
 }
 
 /**
-* @param {Array[]} events The list of events to filter.
-* @param {Object} dateRange The start and end dates to filter events. 
-* @param {Array[]} bodyIDs A list of committee ids to filter events.
-* @return {Array[]} A list of filtered events.
+* @param {Object[]} events The list of events to filter.
+* @param {Object} dateRange The start and end dates to filter events.
+* @param {string} dateRange.start
+* @param {string} dateRange.end 
+* @param {string[]} bodyIDs A list of committee/body ids to filter events.
+* @return {Object[]} A list of filtered events.
 */
 function filterEvents(events, dateRange, bodyIDs) {
   return events.filter(event => {
@@ -313,10 +334,12 @@ function filterEvents(events, dateRange, bodyIDs) {
 }
 
 /**
-* @param {Array[]} events The list of events to sort.
+* @param {Object[]} events The list of events to sort.
 * @param {Object} sortOption The sort by and sort order options.
+* @param {string} sortOption.by
+* @param {string} sortOption.order 
 * @param {boolean} isSearch Whether the list of events is from the search page.
-* @return {Array[]} A list of sorted events according to sortOption.
+* @return {Object[]} A list of events sorted according to sortOption.
 */
 function sortEvents(events, sortOption, isSearch = false) {
   if (sortOption.by && sortOption.order) {

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -15,13 +15,7 @@ const StyledCardContent = styled(Card.Content)({
 const EventCard = ({ name, date, description, link, query }) => (
   <StyledCard fluid>
     <StyledCardContent>
-      <Card.Header>
-        <Link to={{
-          pathname: `${link}`,
-          state: { query: query }
-        }}>
-          {name}
-        </Link>
+      <Card.Header><Link to={query ?  `${link}/${query.trim().replace(/\s+/g, '+')}` : link}>{name}</Link>
       </Card.Header>
       <Card.Meta>{getDateTime(date)}</Card.Meta>
       <Card.Description>{description}</Card.Description>

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -16,7 +16,12 @@ const EventCard = ({ name, date, description, link, query }) => (
   <StyledCard fluid>
     <StyledCardContent>
       <Card.Header>
-        <Link to={query ?  `${link}/${query}` : link}>{name}</Link>
+        <Link to={{
+          pathname: `${link}`,
+          state: { query: query }
+        }}>
+          {name}
+        </Link>
       </Card.Header>
       <Card.Meta>{getDateTime(date)}</Card.Meta>
       <Card.Description>{description}</Card.Description>

--- a/src/components/FilterPopup.jsx
+++ b/src/components/FilterPopup.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Button, Header, Icon, Popup } from 'semantic-ui-react';
 import styled from '@emotion/styled';
-import { isActive } from '../hooks/useFilter';
 
 const ButtonContainer = styled.div({
   display: 'flex',
@@ -36,7 +35,7 @@ const FilterPopup = ({
   mountNodeRef,
   children
 }) => {
-  const { value, clear, getTextRep } = filter;
+  const { clear, getTextRep, isActive } = filter;
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => {
@@ -69,7 +68,7 @@ const FilterPopup = ({
         <Button
           icon
           labelPosition='right'
-          basic={!isActive(value)}>
+          basic={!isActive()}>
           <Icon name='angle down' />
           {getTextRep()}
         </Button>}

--- a/src/components/SelectDateRange.jsx
+++ b/src/components/SelectDateRange.jsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { Form } from 'semantic-ui-react';
 import moment from 'moment';
 
-export const getDateText = (dateRange, filterName) => {
+/**
+ * Generate the text representation of a date range.
+ * @param {Object} dateRange The start and end dates object.
+ * @param {string} dateRange.start
+ * @param {string} dateRange.end
+ * @param {string} defaultText The default text representation, when no dates have been entered.
+ * @return {string} The text representation.
+ */
+export const getDateText = (dateRange, defaultText) => {
   const start = moment.utc(dateRange.start, 'YYYY-MM-DD');
   const end = moment.utc(dateRange.end, 'YYYY-MM-DD');
   const startString = start.format('MMM D, YYYY');
@@ -21,7 +29,7 @@ export const getDateText = (dateRange, filterName) => {
   } else if (dateRange.end) {
     textRep = `- ${endString}`;
   } else {
-    textRep = filterName;
+    textRep = defaultText;
   }
   return textRep;
 };

--- a/src/components/SelectFilterOptions.jsx
+++ b/src/components/SelectFilterOptions.jsx
@@ -3,15 +3,23 @@ import { Form } from 'semantic-ui-react';
 import styled from '@emotion/styled';
 import isSubstring from '../utils/isSubstring'
 
+/**
+ * Generate the text representation of a list of checkboxes, by appending the number of selected checkboxes
+ * to the defaultText.
+ * @param {Object} checkboxes The object representation of the list of checkboxes, 
+ * where the keys are the different options, and each value is a boolean(whether the option is selected).
+ * @param {string} defaultText The default text representation, when no checkboxes are selected.
+ * @returns {string} The text representation.
+ */
+export const getCheckboxText = (checkboxes, defaultText) => {
+  const numberOfSelectedCheckbox = Object.values(checkboxes).filter(value => value).length;
+  const textRep = numberOfSelectedCheckbox ? `${defaultText} : ${numberOfSelectedCheckbox}` : defaultText;
+  return textRep;
+};
+
 const OptionQueryInput = styled(Form.Input)({
   paddingRight: '.8em'
 });
-
-export const getCheckboxText = (filterValue, filterName) => {
-  const numberOfSelectedCheckbox = Object.values(filterValue).filter(value => value).length;
-  const textRep = numberOfSelectedCheckbox ? `${filterName} : ${numberOfSelectedCheckbox}` : filterName;
-  return textRep;
-};
 
 const SelectFilterOptions = ({
   filter,

--- a/src/components/SelectFilterOptions.jsx
+++ b/src/components/SelectFilterOptions.jsx
@@ -3,7 +3,7 @@ import { Form } from 'semantic-ui-react';
 import styled from '@emotion/styled';
 import isSubstring from '../utils/isSubstring'
 
-const SearchCommitteeInput = styled(Form.Input)({
+const OptionQueryInput = styled(Form.Input)({
   paddingRight: '.8em'
 });
 
@@ -16,27 +16,30 @@ export const getCheckboxText = (filterValue, filterName) => {
 const SelectFilterOptions = ({
   filter,
   options,
-  searchCommitteeQuery,
-  setSearchCommitteeQuery,
+  optionQuery,
+  setOptionQuery,
 }) => {
-  const { value, handleChange } = filter;
+  const { filterName, value, handleChange } = filter;
 
   const onChange = (e, { name, checked }) => {
     handleChange(name, checked);
   };
 
-  const onSearchCommiteeChange = (e, { value }) => {
-    setSearchCommitteeQuery(value);
+  const onOptionQueryChange = (e, { value }) => {
+    setOptionQuery(value);
   };
 
-  const filteredOptions = options.filter(({ text }) => isSubstring(text, searchCommitteeQuery));
+  let filteredOptions = options;
+  if (options.length > 5) {
+    filteredOptions = options.filter(({ text }) => isSubstring(text, optionQuery));
+  }
 
   return (
     <Form>
-      <SearchCommitteeInput
-        placeholder='Search Committee Names'
-        value={searchCommitteeQuery}
-        onChange={onSearchCommiteeChange} />
+      {options.length > 5 && <OptionQueryInput
+        placeholder={`Search ${filterName} Options`}
+        value={optionQuery}
+        onChange={onOptionQueryChange} />}
       {filteredOptions.map(option =>
         <Form.Checkbox
           key={option.name}

--- a/src/components/SelectSorting.jsx
+++ b/src/components/SelectSorting.jsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { Form } from 'semantic-ui-react';
 import { ORDER_OPERATORS } from '../api/database';
 
-export const getSortText = (sort, filterName) => {
+/**
+ * Generate the text representation of a sort object.
+ * @param {Object} sort The sort by and sort order options.
+ * @param {string} sort.by
+ * @param {string} sort.order
+ * @param {string} defaultText The default text representation, 
+ * when no sort options are selected.
+ * @return {string} The text representation.
+ */
+export const getSortText = (sort, defaultText) => {
   let by;
   let order;
   if (sort.by) {
@@ -23,7 +32,7 @@ export const getSortText = (sort, filterName) => {
   if (sort.order) {
     order = sort.order === ORDER_OPERATORS.asc ? 'Ascending' : 'Descending';
   }
-  let textRep = filterName;
+  let textRep = defaultText;
   if (by && order) {
     textRep += ` by ${by}: ${order}`;
   } else if (by) {

--- a/src/containers/AllEvents.jsx
+++ b/src/containers/AllEvents.jsx
@@ -6,7 +6,7 @@ import { getDateText } from "../components/SelectDateRange";
 import { getCheckboxText } from "../components/SelectFilterOptions";
 import { getSortText } from "../components/SelectSorting";
 import useDocumentTitle from "../hooks/useDocumentTitle";
-import useFilter, { getSelectedOptions, isSameValue } from "../hooks/useFilter";
+import useFilter, { getSelectedOptions } from "../hooks/useFilter";
 import { getAllEvents, getFilteredEvents } from "../api";
 
 export const FiltersSection = styled.div({
@@ -72,10 +72,12 @@ const EventCardGroupContainer = ({ query }) => {
   const prevDateRangeRef = React.useRef();
   const prevSortRef = React.useRef();
 
+  // handlePopupClose is a callback for when one of the FilterPopups in EventsFilter closes. 
+  // It will perform filtering, depending on whether any of filter values have changed.
   const handlePopupClose = async () => {
-    if (!isSameValue(prevCommitteeRef.current, committeeFilter.value) ||
-      !isSameValue(prevDateRangeRef.current, dateRangeFilter.value) ||
-      !isSameValue(prevSortRef.current, sortFilter.value)) {
+    if (!committeeFilter.isSameValue(prevCommitteeRef.current) ||
+      !dateRangeFilter.isSameValue(prevDateRangeRef.current) ||
+      !sortFilter.isSameValue(prevSortRef.current)) {
       window.scroll(0, 0);
       setFilterEventsComplete(false);
       setVisibleEvents([]);

--- a/src/containers/EventCardGroup.jsx
+++ b/src/containers/EventCardGroup.jsx
@@ -7,7 +7,7 @@ import { getCheckboxText } from "../components/SelectFilterOptions";
 import { getSortText } from "../components/SelectSorting";
 import { FiltersSection, ResultCount, LoadingText, Results } from "./AllEvents";
 import useDocumentTitle from "../hooks/useDocumentTitle";
-import useFilter, { getSelectedOptions, isSameValue } from "../hooks/useFilter";
+import useFilter, { getSelectedOptions } from "../hooks/useFilter";
 import { useHistory } from "react-router-dom";
 import { getEventsByIndexedTerm } from "../api";
 
@@ -56,10 +56,12 @@ const EventCardGroupContainer = ({
   const prevSortRef = React.useRef();
   const prevSearchRef = React.useRef(query);
 
+  // handlePopupClose is a callback for when one of the FilterPopups in EventsFilter closes. 
+  // It will perform filtering, depending on whether any of filter values or the searchQuery have changed.
   const handlePopupClose = () => {
-    if (!isSameValue(prevCommitteeRef.current, committeeFilter.value) ||
-      !isSameValue(prevDateRangeRef.current, dateRangeFilter.value) ||
-      !isSameValue(prevSortRef.current, sortFilter.value) ||
+    if (!committeeFilter.isSameValue(prevCommitteeRef.current) ||
+      !dateRangeFilter.isSameValue(prevDateRangeRef.current) ||
+      !sortFilter.isSameValue(prevSortRef.current) ||
       prevSearchRef.current !== searchQuery) {
       window.scroll(0, 0);
       setInitialGetEventsComplete(false);

--- a/src/containers/EventsFilter.jsx
+++ b/src/containers/EventsFilter.jsx
@@ -10,7 +10,7 @@ const EventsFilter = ({
   handlePopupClose,
   sortByOptions
 }) => {
-  const mountNodeRef = React.useRef();
+  const mountNodeRef = React.useRef(); //where the FilterPopup will be mounted
   const [allBodies, setAllBodies] = React.useState([]);
   const [committeeFilter, dateRangeFilter, sortFilter] = filters;
   const [committeeQuery, setCommitteeQuery] = React.useState('');

--- a/src/containers/EventsFilter.jsx
+++ b/src/containers/EventsFilter.jsx
@@ -13,7 +13,7 @@ const EventsFilter = ({
   const mountNodeRef = React.useRef();
   const [allBodies, setAllBodies] = React.useState([]);
   const [committeeFilter, dateRangeFilter, sortFilter] = filters;
-  const [searchCommitteeQuery, setSearchCommitteeQuery] = React.useState('')
+  const [committeeQuery, setCommitteeQuery] = React.useState('');
 
   const getCommitteeNameOptions = () => {
     return allBodies.map(body => {
@@ -52,8 +52,8 @@ const EventsFilter = ({
         <SelectFilterOptions
           filter={committeeFilter}
           options={getCommitteeNameOptions()}
-          searchCommitteeQuery={searchCommitteeQuery}
-          setSearchCommitteeQuery={setSearchCommitteeQuery} />
+          optionQuery={committeeQuery}
+          setOptionQuery={setCommitteeQuery} />
       </FilterPopup>
       <FilterPopup
         filter={dateRangeFilter}

--- a/src/hooks/useFilter.js
+++ b/src/hooks/useFilter.js
@@ -1,59 +1,88 @@
 import React from 'react';
 
-export function getSelectedOptions(value) {
-  return Object.keys(value).filter(k => value[k]);
-}
-
-export function isActive(value) {
-  return Object.values(value).some(option => option);
-}
-
-export function isSameValue(prevValue, currentValue) {
-  if (!prevValue) {
-    return !isActive(currentValue);
-  }
-  const keys = Object.keys(currentValue);
-  let key;
-  for (key of keys) {
-    if (currentValue[key] && !prevValue.hasOwnProperty(key)) {
-      return false;
-    }
-    if ((currentValue[key] !== prevValue[key]) && prevValue.hasOwnProperty(key)) {
-      return false;
-    }
-  }
-  return true;
+/**
+ * @param {Object} checkboxes The object representation of a list of checkboxes,
+ * where the keys are the different options, and each value is a boolean(whether the option is selected).
+ * @return {string[]} The list of selected options.
+ */
+export function getSelectedOptions(checkboxes) {
+  return Object.keys(checkboxes).filter(k => checkboxes[k]);
 }
 
 /**
-* @param {Object} initialState The inital filter Object, where the keys are the filter options and values are the filter values.
-* @param {string} filterName The name of the filter.
+* @param {Object} initialState The inital filter object, where the keys are the filter options and values are the filter values.
+* @param {string} filterName The name of the filter. It also used as the default text representation,
+* when all filter values are the default filter value.
 * @param {(boolean|string)} defaultData The default filter value.
-* @param {Function} textRepFunction The function to generate the text represenation of the filter object.
-* @return {Object} An object that encapsulates the fitler object state along with other methods to handle state changes.
+* @param {Function} textRepFunction The function to generate the text representation of the filter object.
+* @return {Object} An object that encapsulates the fitler object state along with other methods to handle state changes
+* and get other useful informations about the state.
 */
 function useFilter(initialState, filterName, defaultData, textRepFunction) {
+  // value is the filter object, set is the function that updates it
   const [value, set] = React.useState(initialState);
 
+  /**
+   * Assign the default filter value to all filter options.
+   */
   const clear = () => {
     set(prevValue => {
       const newValue = { ...prevValue };
-      Object.keys(newValue).forEach(k => newValue[k] = defaultData);
+      Object.keys(newValue).forEach(option => newValue[option] = defaultData);
       return newValue;
     });
   }
 
-  const handleChange = (name, dataValue) => {
+  /**
+   * Callback for when a filter value has changed in order
+   * to set the filter option to a new filter value.
+   * @param {string} option The filter option.
+   * @param {(string|boolean)} dataValue The new filter value.
+   */
+  const handleChange = (option, dataValue) => {
     set(prevValue => {
-      return { ...prevValue, [name]: dataValue };
+      return { ...prevValue, [option]: dataValue };
     });
   }
 
+  /**
+   * @return {string} The text representation of the filter object.
+   */
   const getTextRep = () => {
     return textRepFunction(value, filterName);
   }
 
-  return { filterName, value, set, clear, handleChange, getTextRep };
+  /**
+ * 
+ * @return {boolean} Whether any of the filter values does not equal the default filter value.
+ */
+  const isActive = () => {
+    return Object.values(value).some(v => v !== defaultData);
+  }
+
+  /**
+   *
+   * @param {Object} otherValue The other filter object that is of the same type as this filter object.
+   * @return {boolean} Whether the other filter object is the same as this filter object.
+   */
+  const isSameValue = (otherValue) => {
+    if (!otherValue) {
+      return !isActive();
+    }
+    const options = Object.keys(value);
+    let option;
+    for (option of options) {
+      if (value[option] && !otherValue.hasOwnProperty(option)) {
+        return false;
+      }
+      if ((value[option] !== otherValue[option]) && otherValue.hasOwnProperty(option)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return { filterName, value, set, clear, handleChange, getTextRep, isActive, isSameValue };
 }
 
 export default useFilter;

--- a/src/hooks/useFilter.js
+++ b/src/hooks/useFilter.js
@@ -27,7 +27,7 @@ export function isSameValue(prevValue, currentValue) {
 
 /**
 * @param {Object} initialState The inital filter Object, where the keys are the filter options and values are the filter values.
-* @param {Array[]} filterName The name of the filter.
+* @param {string} filterName The name of the filter.
 * @param {(boolean|string)} defaultData The default filter value.
 * @param {Function} textRepFunction The function to generate the text represenation of the filter object.
 * @return {Object} An object that encapsulates the fitler object state along with other methods to handle state changes.

--- a/src/hooks/useFilter.js
+++ b/src/hooks/useFilter.js
@@ -53,7 +53,7 @@ function useFilter(initialState, filterName, defaultData, textRepFunction) {
     return textRepFunction(value, filterName);
   }
 
-  return { value, set, clear, handleChange, getTextRep };
+  return { filterName, value, set, clear, handleChange, getTextRep };
 }
 
 export default useFilter;

--- a/src/pages/Event.jsx
+++ b/src/pages/Event.jsx
@@ -15,13 +15,19 @@ const ContentContainer = styled(Container)({
 const EventPage = ({ match, location }) => {
 
   const parseQuery = () => {
-    // This function gets the query, if there is one, from react-router-dom location.state
+    // This function parses the URL since we couldn't pass the query through state at this time
+    // This solution has the potential to break if the URL changes shape in the future
     // A state management solution would be desirable
-    if (location.state && location.state.query) {
-      return location.state.query;
+    const urlString = location.pathname;
+    const pieces = urlString.split('/');
+    let query;
+    if (pieces.length === 4) {
+      query = pieces[pieces.length - 1];
+      query = query.trim().replace(/\+/g, ' ');
     } else {
-      return '';
+      query = '';
     }
+    return query;
   }
 
   return (

--- a/src/pages/Event.jsx
+++ b/src/pages/Event.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import Event from "../containers/Event";
 import { Container } from "semantic-ui-react";
 import styled from "@emotion/styled";
-import { useLocation } from "react-router-dom";
 
 const Layout = styled(Container)({
   minHeight: "100vh"
@@ -13,28 +12,22 @@ const ContentContainer = styled(Container)({
   marginBottom: "5em !important"
 });
 
-const EventPage = ({ match }) => {
-  const location = useLocation();
+const EventPage = ({ match, location }) => {
 
   const parseQuery = () => {
-    // This function parses the URL since we couldn't pass the query through state at this time
-    // This solution has the potential to break if the URL changes shape in the future
+    // This function gets the query, if there is one, from react-router-dom location.state
     // A state management solution would be desirable
-    const urlString = location.pathname;
-    const pieces = urlString.split('/');
-    let query;
-    if (pieces.length === 4) {
-      query = pieces[pieces.length - 1];
+    if (location.state && location.state.query) {
+      return location.state.query;
     } else {
-      query = '';
+      return '';
     }
-    return query;
   }
-  
+
   return (
     <Layout>
       <ContentContainer>
-        <Event id={match.params.id} query={parseQuery()}/>
+        <Event id={match.params.id} query={parseQuery()} />
       </ContentContainer>
     </Layout>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -26,7 +26,11 @@ const HomePage = props => {
 
   const handleKeyPress = event => {
     if (event.key === "Enter") {
-      props.history.push(`/search?q=${searchQuery}`);
+      props.history.push({
+        pathname: '/search',
+        search: `?q=${searchQuery.trim().replace(/\s+/g, '+')}`,
+        state: { query: searchQuery }
+      });
     }
   };
   const handleSearch = async (e, { value }) => {
@@ -51,7 +55,11 @@ const HomePage = props => {
               attached="right"
               primary
               as={Link}
-              to={`/search?q=${searchQuery}`}
+              to={{
+                pathname: '/search',
+                search: `?q=${searchQuery.trim().replace(/\s+/g, '+')}`,
+                state: { query: searchQuery }
+              }}
             >
               Search
             </Button>

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -14,21 +14,25 @@ const ContentContainer = styled(Container)({
 });
 
 const Search = ({ location }) => {
-  const { q, ids, from, to, sortBy, sortOrder } = queryString.parse(location.search);
-  const committeeFilterValue = {};
-  if(ids) {
-    ids.split(',').forEach(id => committeeFilterValue[id] = true);
+  const { q } = queryString.parse(location.search);
+  let query = q.trim().replace(/\+/g, ' ');
+  let committeeFilterValue = {};
+  let dateRangeFilterValue = { start: '', end: '' };
+  let sortFilterValue = { by: '', order: '' };
+  if (location.state) {
+    query = location.state.query || query;
+    committeeFilterValue = location.state.committeeFilterValue || committeeFilterValue;
+    dateRangeFilterValue = location.state.dateRangeFilterValue || dateRangeFilterValue;
+    sortFilterValue = location.state.sortFilterValue || sortFilterValue;
   }
+
   return (
     <Layout>
       <ContentContainer>
         <EventCardGroup
-          query={q}
-          committeeFilterValue={committeeFilterValue}
-          start={from || ''}
-          end={to || ''}
-          sortBy={sortBy || ''}
-          sortOrder={sortOrder || ''} />
+          query={query}
+          filterValues={[committeeFilterValue, dateRangeFilterValue, sortFilterValue]}
+        />
       </ContentContainer>
     </Layout>
   );


### PR DESCRIPTION
Add some minor fixes to my previous PR #38.

- Make SelectFilterOptions.jsx reusable. For example, it could be used for filtering events by Council Members.

- Remove `ids`, `from`, `to`, `sortBy`, `sortOrder` from the url of /search page. And put that information inside `location.state`

- Resolves #41

- I also added some more documentation as well
