### PR TITLE
bugfix/adjust-media-breakpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,13 +3153,13 @@
       }
     },
     "browserslist": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
+      "integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
       "requires": {
-        "caniuse-lite": "^1.0.30001015",
+        "caniuse-lite": "^1.0.30001017",
         "electron-to-chromium": "^1.3.322",
-        "node-releases": "^1.1.42"
+        "node-releases": "^1.1.44"
       }
     },
     "bser": {
@@ -5352,9 +5352,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
+      "integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -14338,9 +14338,9 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "terser": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
-      "integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.5.1.tgz",
+      "integrity": "sha512-lH9zLIbX8PRBEFCTvfHGCy0s9HEKnNso1Dx9swSopF3VUnFLB8DpQ61tHxoofovNC/sG0spajJM3EIIRSTByiQ==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",

--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -36,7 +36,7 @@ const InfoSegment = styled(Segment.Inline)({
   display: "flex",
   justifyContent: "space-between",
   width: "100%",
-  "@media (min-width:1200px)": {
+  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
     width: "59%"
   }
 });
@@ -53,7 +53,7 @@ const FixedSentinel = styled.div({
 const DummyContainer = styled.div(props => ({
   position: "relative",
   display: "none",
-  "@media (min-width:1200px)": {
+  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
     display: props.isFixed ? "block" : "none",
     width: "59%"
   }
@@ -73,7 +73,7 @@ const PlayerContainer = styled.div(props => ({
   position: "sticky",
   top: "0",
   zIndex: "2",
-  "@media (min-width:1200px)": {
+  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
     position: props.isFixed ? "fixed" : "relative",
     width: props.isFixed ? "20vw" : "59%",
     right: "0"
@@ -101,7 +101,7 @@ const Event = ({
   //isFixed is a boolean, whether the video is fixed to the top-right
   const [isFixed, setIsFixed] = React.useState(false);
   //mediaQueriesMatches is a boolean, whether the video can be fixed to the top-right
-  const mediaQueriesMatches = useMatchMedia("(min-width:1200px)");
+  const mediaQueriesMatches = useMatchMedia("(min-aspect-ratio:5/4), (min-width:1200px)");
   //videoOffSetHeight is used to determine vertical position of event tabs menu when it is sticky
   const [videoOffSetHeight, setVideoOffsetHeight] = React.useState(0);
 

--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -36,7 +36,7 @@ const InfoSegment = styled(Segment.Inline)({
   display: "flex",
   justifyContent: "space-between",
   width: "100%",
-  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
+  "@media (min-width:1200px)": {
     width: "59%"
   }
 });
@@ -53,7 +53,7 @@ const FixedSentinel = styled.div({
 const DummyContainer = styled.div(props => ({
   position: "relative",
   display: "none",
-  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
+  "@media (min-width:1200px)": {
     display: props.isFixed ? "block" : "none",
     width: "59%"
   }
@@ -73,7 +73,7 @@ const PlayerContainer = styled.div(props => ({
   position: "sticky",
   top: "0",
   zIndex: "2",
-  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
+  "@media (min-width:1200px)": {
     position: props.isFixed ? "fixed" : "relative",
     width: props.isFixed ? "20vw" : "59%",
     right: "0"
@@ -101,7 +101,7 @@ const Event = ({
   //isFixed is a boolean, whether the video is fixed to the top-right
   const [isFixed, setIsFixed] = React.useState(false);
   //mediaQueriesMatches is a boolean, whether the video can be fixed to the top-right
-  const mediaQueriesMatches = useMatchMedia("(min-aspect-ratio:5/4), (min-width:1200px)");
+  const mediaQueriesMatches = useMatchMedia("(min-width:1200px)");
   //videoOffSetHeight is used to determine vertical position of event tabs menu when it is sticky
   const [videoOffSetHeight, setVideoOffsetHeight] = React.useState(0);
 

--- a/src/components/EventSearch.jsx
+++ b/src/components/EventSearch.jsx
@@ -10,7 +10,7 @@ const StyledEventSearch = styled.div({
   display: "flex",
   flexDirection: "column",
   boxSizing: "border-box",
-  "@media (min-width:1200px)": {
+  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
     width: "38%",
     margin: "0 0 0 20px"
   }
@@ -45,7 +45,7 @@ const SearchResultsWrapper = styled.div({
   borderRadius: "0.28rem",
   boxSizing: "border-box",
   minHeight: "calc(.5625 * 90vw)",
-  "@media (min-width:1200px)": {
+  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
     flex: "1 1 auto",
     minHeight: "0"
   }

--- a/src/components/EventSearch.jsx
+++ b/src/components/EventSearch.jsx
@@ -10,9 +10,9 @@ const StyledEventSearch = styled.div({
   display: "flex",
   flexDirection: "column",
   boxSizing: "border-box",
-  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
-    width: "40%",
-    margin: "0"
+  "@media (min-width:1200px)": {
+    width: "38%",
+    margin: "0 0 0 20px"
   }
 });
 
@@ -45,7 +45,7 @@ const SearchResultsWrapper = styled.div({
   borderRadius: "0.28rem",
   boxSizing: "border-box",
   minHeight: "calc(.5625 * 90vw)",
-  "@media (min-aspect-ratio:5/4), (min-width:1200px)": {
+  "@media (min-width:1200px)": {
     flex: "1 1 auto",
     minHeight: "0"
   }

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -34,7 +34,8 @@ const TimeStamp = styled.div(props => ({
   "@media(max-width:1000px)": {
     width: "100%",
     padding: "0",
-    order: "1"
+    order: "1",
+    margin: "10px 0px 0px 0px"
   }
 }));
 

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -20,7 +20,7 @@ const TranscriptItemText = styled.div(props => ({
   boxSizing: "border-box",
   fontSize: "16px",
   lineHeight: "1.5em",
-  "@media(max-width:720px)": {
+  "@media(max-width:1000px)": {
     width: "100%",
     order: "0"
   }
@@ -31,7 +31,7 @@ const TimeStamp = styled.div(props => ({
   order: props.isSearch ? "1" : "0",
   boxSizing: "border-box",
   padding: props.isSearch ? "0" : "0.5em",
-  "@media(max-width:720px)": {
+  "@media(max-width:1000px)": {
     width: "100%",
     padding: "0",
     order: "1"


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.

While playing around with picture in picture adjustments and experimenting with breakpoints the nitpickiness in me found two small changes that I think result in a better UI given any size window.

The first is an adjustment to when the event search component drops to below the video. I just set it at `1200px` nothing else special and it seems to looks pretty good.

The second is adjustment to when the timestamps drop to below each sentence text. Which is now set to `1000px`. This one was because there was a weird spot in between `720px` and `1000px` that resulted in the play icon and the timestamp text being on a split line. This makes it so that the icon and the timestamp text will always be on the same line.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
