### PR TITLE
[GH-51]feature/add-timestamped-speaker-turns

### DIFF
--- a/src/api/eventApi.js
+++ b/src/api/eventApi.js
@@ -150,7 +150,7 @@ export async function getEventById(id) {
         .utc(event.event_datetime.toMillis())
         .toISOString(),
       minutes: minutesItems,
-      transcript: transcript.data,
+      transcript: transcript,
       scPageUrl: event.source_uri,
       votes: votes
     };

--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -203,7 +203,6 @@ const Event = ({
       <EventSearch
         transcript={getTranscriptTimestampedText()}
         handleSeek={handleSeek}
-        mediaQueriesMatches={mediaQueriesMatches}
         query={query}
       />
       <EventTabs

--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -213,7 +213,6 @@ const Event = ({
         handleSeek={handleSeek}
         topOffset={mediaQueriesMatches ? 0 : videoOffSetHeight} //vertical position of event tabs menu when it is sticky
         mediaQueriesMatches={mediaQueriesMatches}
-        videoTimePoint={videoTimePoint}
       />
     </StyledEvent>
   );

--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -149,6 +149,19 @@ const Event = ({
     }
   };
 
+  const getTranscriptTimestampedText = () => {
+    if (transcript.format.includes("speaker-turns")) {
+      // Flatten speaker turn blocks to timestamped sentences
+      let timestampedSentences = [];
+      transcript.data.forEach(speakerTurnBlock => {
+        timestampedSentences.push(...speakerTurnBlock.data)
+      });
+      return timestampedSentences;
+    }
+    // Return timestamped texts if transcript format is not `timestamped-speaker-turns`
+    return transcript.data;
+  }
+
   return (
     <StyledEvent>
       <Header>
@@ -188,7 +201,7 @@ const Event = ({
         </Player>
       </PlayerContainer>
       <EventSearch
-        transcript={transcript}
+        transcript={getTranscriptTimestampedText()}
         handleSeek={handleSeek}
         mediaQueriesMatches={mediaQueriesMatches}
         query={query}

--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -154,7 +154,7 @@ const Event = ({
       // Flatten speaker turn blocks to timestamped sentences
       let timestampedSentences = [];
       transcript.data.forEach(speakerTurnBlock => {
-        timestampedSentences.push(...speakerTurnBlock.data)
+        timestampedSentences.push(...speakerTurnBlock.data);
       });
       return timestampedSentences;
     }
@@ -214,6 +214,7 @@ const Event = ({
         handleSeek={handleSeek}
         topOffset={mediaQueriesMatches ? 0 : videoOffSetHeight} //vertical position of event tabs menu when it is sticky
         mediaQueriesMatches={mediaQueriesMatches}
+        videoTimePoint={videoTimePoint}
       />
     </StyledEvent>
   );

--- a/src/components/EventSearch.jsx
+++ b/src/components/EventSearch.jsx
@@ -54,16 +54,12 @@ const SearchResultsWrapper = styled.div({
 const EventSearch = ({
   transcript,
   handleSeek,
-  mediaQueriesMatches,
   query
 }) => {
   const [transcriptSearchText, setTranscriptSearchText] = React.useState(query);
 
   const handleTranscriptSearch = (e, { value }) => {
     setTranscriptSearchText(value);
-    if(!mediaQueriesMatches) {
-      document.dispatchEvent(new CustomEvent("update-scroll-position"));
-    }
   };
 
   const transcriptItems = transcript.filter(({ text }) => isSubstring(text, transcriptSearchText));

--- a/src/components/EventSearch.jsx
+++ b/src/components/EventSearch.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Input } from "semantic-ui-react";
 import styled from "@emotion/styled";
-import EventTranscript from "./EventTranscript";
+import EventTranscriptSearch from "./EventTranscriptSearch";
 import isSubstring from "../utils/isSubstring";
 
 const StyledEventSearch = styled.div({
@@ -83,11 +83,10 @@ const EventSearch = ({
       )}
       {transcriptSearchText !== "" && transcriptItems.length > 0 && (
         <SearchResultsWrapper>
-          <EventTranscript
+          <EventTranscriptSearch
             searchText={transcriptSearchText}
             transcript={transcriptItems}
             handleSeek={handleSeek}
-            isSearch={true}
           />
         </SearchResultsWrapper>
       )}

--- a/src/components/EventTabs.jsx
+++ b/src/components/EventTabs.jsx
@@ -92,7 +92,6 @@ const EventTabs = ({
         transcript: <EventTranscript
           transcriptHasScrolledToVideoTimePointRef={transcriptHasScrolledToVideoTimePointRef}
           handleSeek={handleSeek}
-          mediaQueriesMatches={mediaQueriesMatches}
           transcript={transcript}
           videoTimePoint={videoTimePointState}
         />,

--- a/src/components/EventTabs.jsx
+++ b/src/components/EventTabs.jsx
@@ -66,10 +66,8 @@ const EventTabs = ({
       {{
         details: <EventMinutes minutes={minutes} scPageUrl={scPageUrl} />,
         transcript: <EventTranscript
-          searchText={""}
           transcript={transcript}
           handleSeek={handleSeek}
-          isSearch={false}
         />,
         votes: votes.length ? <VotingTable votingData={votes} /> : <div>No votes found for this event.</div>
       }[activeItem]}

--- a/src/components/EventTabs.jsx
+++ b/src/components/EventTabs.jsx
@@ -35,12 +35,14 @@ const EventTabs = ({
   videoTimePoint
 }) => {
   // Which menu item is visible
-  const [activeItem, setActiveItem] = React.useState(videoTimePoint ? "transcript": "details");
+  const [activeItem, setActiveItem] = React.useState(videoTimePoint ? "transcript" : "details");
   // A React reference to StyledEventTabs
   const contextRef = React.useRef(null);
   // A React reference to hold a boolean, whether has already scrolled to transcript portion that contains videoTimePoint
   // Needed so that it automatically scroll to that transcript portion only once.
-  const transcriptHasScrolledToVideoTimePoint = React.useRef(false);
+  const transcriptHasScrolledToVideoTimePointRef = React.useRef(false);
+  // videoTimePoint as a React state
+  const [videoTimePointState, setVideoTimePointState] = React.useState(videoTimePoint);
 
   // Callback to handle menu item click event
   const handleItemClick = (e, { name }) => {
@@ -59,6 +61,19 @@ const EventTabs = ({
     setActiveItem(name);
   };
 
+  React.useEffect(() => {
+    // Callback to handle custom scroll-to-transcript-item event.
+    const handleScrollToTranscriptItem = (event) => {
+      setActiveItem("transcript");
+      transcriptHasScrolledToVideoTimePointRef.current = false;
+      setVideoTimePointState(event.detail.videoTimePoint);
+    };
+    document.addEventListener("scroll-to-transcript-item", handleScrollToTranscriptItem);
+    return () => {
+      document.removeEventListener("scroll-to-transcript-item", handleScrollToTranscriptItem);
+    };
+  }, []);
+
   return (
     <StyledEventTabs ref={contextRef}>
       <Sticky
@@ -75,10 +90,11 @@ const EventTabs = ({
       {{
         details: <EventMinutes minutes={minutes} scPageUrl={scPageUrl} />,
         transcript: <EventTranscript
-          transcriptHasScrolledToVideoTimePoint={transcriptHasScrolledToVideoTimePoint}
+          transcriptHasScrolledToVideoTimePointRef={transcriptHasScrolledToVideoTimePointRef}
           handleSeek={handleSeek}
+          mediaQueriesMatches={mediaQueriesMatches}
           transcript={transcript}
-          videoTimePoint={videoTimePoint}
+          videoTimePoint={videoTimePointState}
         />,
         votes: votes.length ? <VotingTable votingData={votes} /> : <div>No votes found for this event.</div>
       }[activeItem]}

--- a/src/components/EventTabs.jsx
+++ b/src/components/EventTabs.jsx
@@ -31,18 +31,12 @@ const EventTabs = ({
   votes,
   handleSeek,
   topOffset,
-  mediaQueriesMatches,
-  videoTimePoint
+  mediaQueriesMatches
 }) => {
   // Which menu item is visible
-  const [activeItem, setActiveItem] = React.useState(videoTimePoint ? "transcript" : "details");
+  const [activeItem, setActiveItem] = React.useState("details");
   // A React reference to StyledEventTabs
   const contextRef = React.useRef(null);
-  // A React reference to hold a boolean, whether has already scrolled to transcript portion that contains videoTimePoint
-  // Needed so that it automatically scroll to that transcript portion only once.
-  const transcriptHasScrolledToVideoTimePointRef = React.useRef(false);
-  // videoTimePoint as a React state
-  const [videoTimePointState, setVideoTimePointState] = React.useState(videoTimePoint);
 
   // Callback to handle menu item click event
   const handleItemClick = (e, { name }) => {
@@ -61,19 +55,6 @@ const EventTabs = ({
     setActiveItem(name);
   };
 
-  React.useEffect(() => {
-    // Callback to handle custom scroll-to-transcript-item event.
-    const handleScrollToTranscriptItem = (event) => {
-      setActiveItem("transcript");
-      transcriptHasScrolledToVideoTimePointRef.current = false;
-      setVideoTimePointState(event.detail.videoTimePoint);
-    };
-    document.addEventListener("scroll-to-transcript-item", handleScrollToTranscriptItem);
-    return () => {
-      document.removeEventListener("scroll-to-transcript-item", handleScrollToTranscriptItem);
-    };
-  }, []);
-
   return (
     <StyledEventTabs ref={contextRef}>
       <Sticky
@@ -90,10 +71,8 @@ const EventTabs = ({
       {{
         details: <EventMinutes minutes={minutes} scPageUrl={scPageUrl} />,
         transcript: <EventTranscript
-          transcriptHasScrolledToVideoTimePointRef={transcriptHasScrolledToVideoTimePointRef}
           handleSeek={handleSeek}
           transcript={transcript}
-          videoTimePoint={videoTimePointState}
         />,
         votes: votes.length ? <VotingTable votingData={votes} /> : <div>No votes found for this event.</div>
       }[activeItem]}

--- a/src/components/EventTabs.jsx
+++ b/src/components/EventTabs.jsx
@@ -31,22 +31,31 @@ const EventTabs = ({
   votes,
   handleSeek,
   topOffset,
-  mediaQueriesMatches
+  mediaQueriesMatches,
+  videoTimePoint
 }) => {
-  const [activeItem, setActiveItem] = React.useState("details");
+  // Which menu item is visible
+  const [activeItem, setActiveItem] = React.useState(videoTimePoint ? "transcript": "details");
+  // A React reference to StyledEventTabs
   const contextRef = React.useRef(null);
+  // A React reference to hold a boolean, whether has already scrolled to transcript portion that contains videoTimePoint
+  // Needed so that it automatically scroll to that transcript portion only once.
+  const transcriptHasScrolledToVideoTimePoint = React.useRef(false);
 
-  React.useEffect(() => {
+  // Callback to handle menu item click event
+  const handleItemClick = (e, { name }) => {
     const domRect = contextRef.current.getBoundingClientRect();
     if (domRect.top < 0) {
+      // If the top of contextRef is not visible, scroll so that the top of contextRef
+      // is aligned with the top of viewport.
       contextRef.current.scrollIntoView(true);
       if (!mediaQueriesMatches) {
+        // This is the case where video is fixed to the top and Menu is below the video.
+        // Need to scroll upward by video's height so that the, for example, first minute is visible
+        // below the menu.
         window.scrollBy(0, -topOffset);
       }
     }
-  }, [activeItem, mediaQueriesMatches, topOffset]);
-
-  const handleItemClick = (e, { name }) => {
     setActiveItem(name);
   };
 
@@ -66,8 +75,10 @@ const EventTabs = ({
       {{
         details: <EventMinutes minutes={minutes} scPageUrl={scPageUrl} />,
         transcript: <EventTranscript
-          transcript={transcript}
+          transcriptHasScrolledToVideoTimePoint={transcriptHasScrolledToVideoTimePoint}
           handleSeek={handleSeek}
+          transcript={transcript}
+          videoTimePoint={videoTimePoint}
         />,
         votes: votes.length ? <VotingTable votingData={votes} /> : <div>No votes found for this event.</div>
       }[activeItem]}

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -1,49 +1,43 @@
 import React from "react";
-import { Button } from "semantic-ui-react";
-import { AutoSizer, CellMeasurer, CellMeasurerCache, List, WindowScroller } from 'react-virtualized';
-import { Icon } from "semantic-ui-react";
-import Highlighter from "react-highlight-words";
+import { Button, Icon } from "semantic-ui-react";
+import { AutoSizer, CellMeasurer, CellMeasurerCache, List, WindowScroller } from "react-virtualized";
 import styled from "@emotion/styled";
 import hhmmss from "../utils/hhmmss";
 
 const TranscriptItem = styled.div({
   display: "flex",
   flexWrap: "wrap",
+  justifyContent: "space-between",
   alignItems: "center",
-  margin: "1em 0",
-  padding: "0.2em"
+  margin: "1em 0.2em"
 });
 
-const TranscriptItemText = styled.div(props => ({
-  width: props.isSearch ? "100%" : "85%",
-  order: props.isSearch ? "0" : "1",
-  boxSizing: "border-box",
+const TranscriptItemText = styled.div({
+  width: "100%",
   fontSize: "16px",
-  lineHeight: "1.5em",
-  "@media(max-width:1000px)": {
-    width: "100%",
+  marginBottom: "0.1em",
+  "@media(min-width:720px)": {
+    width: "85%",
+    order: "1",
+    marginBottom: "0"
+  }
+});
+
+const TimeStamp = styled.div({
+  width: "100%",
+  ".ui.button": {
+    // Make timestamp button's padding smaller
+    padding: "0.5em !important"
+  },
+  "@media(min-width:720px)": {
+    width: "15%",
     order: "0"
   }
-}));
-
-const TimeStamp = styled.div(props => ({
-  width: props.isSearch ? "100%" : "15%",
-  order: props.isSearch ? "1" : "0",
-  boxSizing: "border-box",
-  padding: props.isSearch ? "0" : "0.5em",
-  "@media(max-width:1000px)": {
-    width: "100%",
-    padding: "0",
-    order: "1",
-    margin: "10px 0px 0px 0px"
-  }
-}));
+});
 
 const EventTranscript = ({
-  searchText,
   transcript,
-  handleSeek,
-  isSearch
+  handleSeek
 }) => {
   const windowScrollerRef = React.useRef(null);
 
@@ -78,65 +72,42 @@ const EventTranscript = ({
     >
       <div style={style}>
         <TranscriptItem>
-          <TimeStamp isSearch={isSearch}>
-            <Button size="tiny" onClick={() => handleSeek(transcript[index].start_time)}>
+          <TranscriptItemText>
+            {transcript[index].text}
+          </TranscriptItemText>
+          <TimeStamp>
+            <Button size="small" onClick={() => handleSeek(transcript[index].start_time)}>
               <Icon name="play" />
               {hhmmss(transcript[index].start_time)}
             </Button>
           </TimeStamp>
-          <TranscriptItemText isSearch={isSearch}>
-            <Highlighter
-              searchWords={[searchText]}
-              autoEscape={true}
-              textToHighlight={transcript[index].text}
-            />
-          </TranscriptItemText>
         </TranscriptItem>
       </div>
     </CellMeasurer>
   );
 
-  if (isSearch) {
-    return (
-      <AutoSizer onResize={onResize}>
-        {({ width, height }) => (
-          <List
-            deferredMeasurementCache={cache}
-            height={height}
-            rowCount={transcript.length}
-            rowHeight={cache.rowHeight}
-            rowRenderer={Row}
-            scrollToIndex={0}
-            style={{ willChange: "" }}
-            width={width}
-          />
-        )}
-      </AutoSizer>
-    );
-  } else {
-    return (
-      <WindowScroller ref={windowScrollerRef}>
-        {({ height, isScrolling, onChildScroll, scrollTop }) => (
-          <AutoSizer disableHeight onResize={onResize}>
-            {({ width }) => (
-              <List
-                autoHeight
-                deferredMeasurementCache={cache}
-                height={height}
-                isScrolling={isScrolling}
-                onScroll={onChildScroll}
-                rowCount={transcript.length}
-                rowHeight={cache.rowHeight}
-                rowRenderer={Row}
-                scrollTop={scrollTop}
-                style={{ willChange: "" }}
-                width={width}
-              />)}
-          </AutoSizer>
-        )}
-      </WindowScroller>
-    );
-  }
+  return (
+    <WindowScroller ref={windowScrollerRef}>
+      {({ height, isScrolling, onChildScroll, scrollTop }) => (
+        <AutoSizer disableHeight onResize={onResize}>
+          {({ width }) => (
+            <List
+              autoHeight
+              deferredMeasurementCache={cache}
+              height={height}
+              isScrolling={isScrolling}
+              onScroll={onChildScroll}
+              rowCount={transcript.length}
+              rowHeight={cache.rowHeight}
+              rowRenderer={Row}
+              scrollTop={scrollTop}
+              style={{ willChange: "" }}
+              width={width}
+            />)}
+        </AutoSizer>
+      )}
+    </WindowScroller>
+  );
 };
 
 export default React.memo(EventTranscript);

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -47,7 +47,7 @@ const TimeStamp = styled.div({
  * @param {Number} transcriptItem.start_time
  * @param {Number} transcriptItem.end_time
  * @param {String} [transcriptItem.speaker]
- * @param {Object} transcriptItemRef A React reference
+ * @param {Object} transcriptItemRef A React reference to the transcript item in the DOM
  * @param {Boolean} isSpeakerTurnFormat Whether transcriptItem is from timestamped-speaker-turns format.
  * @param {Function} handleSeek Callback to change the event video's current time to the start_time.
  * @return The JSX of the transcript item.
@@ -119,7 +119,6 @@ const findTranscriptItemIndex = (videoTimePoint, transcriptItems) => {
 const EventTranscript = ({
   transcriptHasScrolledToVideoTimePointRef,
   handleSeek,
-  mediaQueriesMatches,
   transcript,
   videoTimePoint
 }) => {
@@ -144,19 +143,13 @@ const EventTranscript = ({
     let transcriptItemIndex = findTranscriptItemIndex(videoTimePoint, transcriptItems);
     if (transcriptItemIndex >= 0 && !transcriptHasScrolledToVideoTimePointRef.current) {
       const transcriptItemRef = transcriptItemRefs[transcriptItemIndex];
-      const transcriptItemDomRect = transcriptItemRef.current.getBoundingClientRect();
       transcriptItemRef.current.scrollIntoView(true);
       // transcript item may be covered by menu and/or video
-      if (mediaQueriesMatches) {
-        // scroll upward by max of 100 or transcript item's height
-        window.scrollBy(0, -Math.max(100, transcriptItemDomRect.height));
-      } else {
-        // scroll upward by half of window's height
-        window.scrollBy(0, -window.innerHeight/2);
-      }
+      // scroll upward by half of window's height
+      window.scrollBy(0, -window.innerHeight / 2);
       transcriptHasScrolledToVideoTimePointRef.current = true;
     }
-  }, [mediaQueriesMatches, transcriptHasScrolledToVideoTimePointRef, transcriptItems, transcriptItemRefs, videoTimePoint]);
+  }, [transcriptHasScrolledToVideoTimePointRef, transcriptItems, transcriptItemRefs, videoTimePoint]);
 
   return (
     <div>

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -17,6 +17,7 @@ const TranscriptItem = styled.div(props => ({
 const TranscriptItemText = styled.div({
   width: "100%",
   fontSize: "16px",
+  lineHeight: "1.5em",
   "@media(min-width:1000px)": {
     // For screen width >= 1000px
     // Decrease text's width

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -1,99 +1,151 @@
 import React from "react";
-import { Button, Header, Icon, Segment } from "semantic-ui-react";
+import { Button, Divider, Header, Icon } from "semantic-ui-react";
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List, WindowScroller } from "react-virtualized";
 import styled from "@emotion/styled";
 import hhmmss from "../utils/hhmmss";
 
-const TranscriptBlock = styled(Segment)({
-  // Increase the vertical spacing between each transcript block
-  margin: "0.5em 0 !important"
-});
-
-const TranscriptItem = styled.div({
+const TranscriptItem = styled.div(props => ({
   display: "flex",
   flexWrap: "wrap",
   justifyContent: "space-between",
   alignItems: "center",
-  // Increase the spacing around each timestamped text
-  margin: "1em 0.2em",
-});
+  // Make vertical spacing between transcript items of timestamped-speaker-turns format a little
+  // bit smaller than other transcript formats.
+  margin: props.isSpeakerTurnFormat ? "0.8em 0.2em" : "1.2em 0.2em"
+}));
 
 const TranscriptItemText = styled.div({
   width: "100%",
   fontSize: "16px",
-  marginBottom: "0.1em",
-  "@media(min-width:720px)": {
-    // For screen width >= 720px
-    // Decrease width
+  "@media(min-width:1000px)": {
+    // For screen width >= 1000px
+    // Decrease text's width
     width: "85%",
-    // Make it appear timestamp button
-    order: "1",
-    marginBottom: "0"
+    // Make it appear after TimeStamp
+    order: "1"
   }
 });
 
 const TimeStamp = styled.div({
   width: "100%",
-  ".ui.button": {
-    // Make timestamp button's padding smaller
-    padding: "0.5em !important"
-  },
-  "@media(min-width:720px)": {
-    // For screen width >= 720px
-    // Decrease width
+  // Increase the vertical spacing between TranscriptItemText and Timestamp
+  marginTop: "10px",
+  "@media(min-width:1000px)": {
+    // For screen width >= 1000px
+    // Decrease timestamp's width
     width: "15%",
-    // Make it appear before timestamped text
-    order: "0"
+    // Make it appear before TranscriptItemText
+    order: "0",
+    marginTop: "0"
   }
 });
 
 /**
  * 
- * @param {Object} transcriptBlock The transcript block. It could be a timestamped text with fields: text, start_time, end_time. 
- * Or it could be a speaker turn block with fields speaker and data. With data being a list of timestamped text.
- * @param {String} transcriptFormat The transcript's format.
- * @param {Function} handleSeek Callback to change the event video's current time to the start_time of a timestamped text
- * @return The JSX of the transcript block.
+ * @param {Object} transcriptItem The transcript item.
+ * @param {String} transcriptItem.text
+ * @param {Number} transcriptItem.start_time
+ * @param {Number} transcriptItem.end_time
+ * @param {String} [transcriptItem.speaker]
+ * @param {Boolean} isSpeakerTurnFormat Whether transcriptItem is from timestamped-speaker-turns format.
+ * @param {Function} handleSeek Callback to change the event video's current time to the start_time.
+ * @return The JSX of the transcript item.
  */
-const transcriptBlockRenderer = (transcriptBlock, transcriptFormat, handleSeek) => {
-  const isSpeakerTurnBlock = transcriptFormat.includes("speaker-turns");
-  const timestamptedTexts = isSpeakerTurnBlock ?
-    transcriptBlock.data :
-    [transcriptBlock];
-
+const transcriptItemRenderer = (transcriptItem, isSpeakerTurnFormat, handleSeek) => {
   return (
-    <TranscriptBlock>
-      {(isSpeakerTurnBlock && transcriptBlock.speaker) && <Header as="h4">{transcriptBlock.speaker}</Header>}
-      {timestamptedTexts.map((timestampedText) => (
-        <TranscriptItem key={timestampedText.start_time}>
-          <TranscriptItemText>
-            {timestampedText.text}
-          </TranscriptItemText>
-          <TimeStamp>
-            <Button size="small" onClick={() => handleSeek(timestampedText.start_time)}>
-              <Icon name="play" />
-              {hhmmss(timestampedText.start_time)}
-            </Button>
-          </TimeStamp>
-        </TranscriptItem>))}
-    </TranscriptBlock>
+    <div>
+      {(!!transcriptItem.speaker) &&
+        <Divider horizontal>
+          <Header as='h3'>
+            {transcriptItem.speaker}
+          </Header>
+        </Divider>}
+      <TranscriptItem isSpeakerTurnFormat={isSpeakerTurnFormat}>
+        <TranscriptItemText>
+          {transcriptItem.text}
+        </TranscriptItemText>
+        <TimeStamp>
+          <Button size="tiny" onClick={() => handleSeek(transcriptItem.start_time)}>
+            <Icon name="play" />
+            {hhmmss(transcriptItem.start_time)}
+          </Button>
+        </TimeStamp>
+      </TranscriptItem>
+    </div>
   );
 };
 
-const EventTranscript = ({
-  transcript,
-  handleSeek
-}) => {
-  // A React reference to the WindowScroller
-  const windowScrollerRef = React.useRef(null);
+/**
+ * Use binary search to find transcriptItem's index from videoTimePoint
+ * @param {Number} videoTimePoint The video time point
+ * @param {Array} transcriptItems List of transcript items
+ * @return {Number} The index of a transcript item that is close in time to videoTimePoint.
+ */
+const findTranscriptItemIndex = (videoTimePoint, transcriptItems) => {
+  if (videoTimePoint < transcriptItems[0].start_time) {
+    return 0;
+  }
+  if (videoTimePoint > transcriptItems[transcriptItems.length - 1].end_time) {
+    return transcriptItems.length - 1;
+  }
+  let left = 0;
+  let right = transcriptItems.length - 1;
+  while (left <= right) {
+    let mid = Math.floor(left + (right - left) / 2);
+    let transcriptItem = transcriptItems[mid];
+    if (videoTimePoint >= transcriptItem.start_time && videoTimePoint <= transcriptItem.end_time) {
+      // videoTimePoint is between mid transcript item's timestamp
+      return mid;
+    } else if (videoTimePoint >= transcriptItems[mid - 1].end_time && videoTimePoint <= transcriptItem.start_time) {
+      // videoTimePoint is within the timestamped gap that is between mid and mid-1 transcript items
+      // e.g. mid-1.end_time,videoTimePoint,mid.start_time
+      return mid;
+    } else if (videoTimePoint >= transcriptItem.end_time && videoTimePoint <= transcriptItems[mid + 1].start_time) {
+      // videoTimePoint is within the timestamped gap that is between mid and m+1 transcript items
+      // e.g. mid.end_time,videoTimePoint,mid+1.start_time
+      return mid + 1;
+    } else if (videoTimePoint > transcriptItem.end_time) {
+      // videoTimePoint greater than mid.end_time
+      left = mid + 1;
+    } else {
+      // videoTimePoint is less than mid.start_time
+      right = mid - 1;
+    }
+  }
+  return -1;
+};
 
-  // Stores the CellMeasurer's measurements of all transcript blocks
-  const cache = new CellMeasurerCache({
-    // The width of transcript blocks are the same
-    fixedWidth: true,
-    // The height of transcript blocks are variable, with the default height being 100px
-    defaultHeight: 100,
-  });
+const EventTranscript = ({
+  transcriptHasScrolledToVideoTimePoint,
+  handleSeek,
+  transcript,
+  videoTimePoint
+}) => {
+  // A React reference to react-virtualized WindowScroller
+  const windowScrollerRef = React.useRef(null);
+  // A React reference to react-virtualized List
+  const listRef = React.useRef(null);
+  // List of timestamped texts
+  let transcriptItems = [];
+  const isSpeakerTurnFormat = transcript.format.includes("speaker-turns");
+  if (isSpeakerTurnFormat) {
+    transcript.data.forEach(speakerTurn => {
+      // Add speaker field for first timestamped sentence
+      speakerTurn.data[0].speaker = speakerTurn.speaker || "New Speaker";
+      transcriptItems.push(...speakerTurn.data);
+    });
+  } else {
+    transcriptItems = transcript.data;
+  }
+
+  React.useEffect(() => {
+    let transcriptItemIndex = findTranscriptItemIndex(videoTimePoint, transcriptItems);
+    if (transcriptItemIndex > 0 && !transcriptHasScrolledToVideoTimePoint.current) {
+      // Scroll to transcript item
+      listRef.current.scrollToRow(transcriptItemIndex);
+      transcriptHasScrolledToVideoTimePoint.current = true;
+    }
+  }, [transcriptHasScrolledToVideoTimePoint, transcriptItems, videoTimePoint]);
 
   React.useEffect(() => {
     const handleUpdateScrollPosition = () => {
@@ -108,14 +160,22 @@ const EventTranscript = ({
     };
   }, []);
 
+  // Stores the CellMeasurer's measurements of all transcript items
+  const cache = new CellMeasurerCache({
+    // The width of transcript items are the same
+    fixedWidth: true,
+    // The height of transcript items are variable, with the default height being 100px
+    defaultHeight: 100,
+  });
+
   const onResize = () => {
-    // Need to clear all transcript blocks' measurements on document resize
+    // Need to clear all transcript items' measurements on document resize
     cache.clearAll();
   };
 
   const Row = ({ index, parent, key, style }) => (
-    // Row is responsible for rendering a transcript block
-    // CellMeasurer will dynamically determine the height of a transcript block,
+    // Row is responsible for rendering a transcript item
+    // CellMeasurer will dynamically determine the height of a transcript item,
     // or use the cache to determine the height
     <CellMeasurer
       key={key}
@@ -125,7 +185,7 @@ const EventTranscript = ({
       rowIndex={index}
     >
       <div style={style}>
-        {transcriptBlockRenderer(transcript.data[index], transcript.format, handleSeek)}
+        {transcriptItemRenderer(transcriptItems[index], transcript.format.includes("speaker-turns"), handleSeek)}
       </div>
     </CellMeasurer>
   );
@@ -141,9 +201,11 @@ const EventTranscript = ({
               height={height}
               isScrolling={isScrolling}
               onScroll={onChildScroll}
-              rowCount={transcript.data.length}
+              ref={listRef}
+              rowCount={transcriptItems.length}
               rowHeight={cache.rowHeight}
               rowRenderer={Row}
+              scrollToAlignment={"center"}
               scrollTop={scrollTop}
               style={{ willChange: "" }}
               width={width}

--- a/src/components/EventTranscript.jsx
+++ b/src/components/EventTranscript.jsx
@@ -1,15 +1,21 @@
 import React from "react";
-import { Button, Icon } from "semantic-ui-react";
+import { Button, Header, Icon, Segment } from "semantic-ui-react";
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List, WindowScroller } from "react-virtualized";
 import styled from "@emotion/styled";
 import hhmmss from "../utils/hhmmss";
+
+const TranscriptBlock = styled(Segment)({
+  // Increase the vertical spacing between each transcript block
+  margin: "0.5em 0 !important"
+});
 
 const TranscriptItem = styled.div({
   display: "flex",
   flexWrap: "wrap",
   justifyContent: "space-between",
   alignItems: "center",
-  margin: "1em 0.2em"
+  // Increase the spacing around each timestamped text
+  margin: "1em 0.2em",
 });
 
 const TranscriptItemText = styled.div({
@@ -17,7 +23,10 @@ const TranscriptItemText = styled.div({
   fontSize: "16px",
   marginBottom: "0.1em",
   "@media(min-width:720px)": {
+    // For screen width >= 720px
+    // Decrease width
     width: "85%",
+    // Make it appear timestamp button
     order: "1",
     marginBottom: "0"
   }
@@ -30,25 +39,66 @@ const TimeStamp = styled.div({
     padding: "0.5em !important"
   },
   "@media(min-width:720px)": {
+    // For screen width >= 720px
+    // Decrease width
     width: "15%",
+    // Make it appear before timestamped text
     order: "0"
   }
 });
+
+/**
+ * 
+ * @param {Object} transcriptBlock The transcript block. It could be a timestamped text with fields: text, start_time, end_time. 
+ * Or it could be a speaker turn block with fields speaker and data. With data being a list of timestamped text.
+ * @param {String} transcriptFormat The transcript's format.
+ * @param {Function} handleSeek Callback to change the event video's current time to the start_time of a timestamped text
+ * @return The JSX of the transcript block.
+ */
+const transcriptBlockRenderer = (transcriptBlock, transcriptFormat, handleSeek) => {
+  const isSpeakerTurnBlock = transcriptFormat.includes("speaker-turns");
+  const timestamptedTexts = isSpeakerTurnBlock ?
+    transcriptBlock.data :
+    [transcriptBlock];
+
+  return (
+    <TranscriptBlock>
+      {(isSpeakerTurnBlock && transcriptBlock.speaker) && <Header as="h4">{transcriptBlock.speaker}</Header>}
+      {timestamptedTexts.map((timestampedText) => (
+        <TranscriptItem key={timestampedText.start_time}>
+          <TranscriptItemText>
+            {timestampedText.text}
+          </TranscriptItemText>
+          <TimeStamp>
+            <Button size="small" onClick={() => handleSeek(timestampedText.start_time)}>
+              <Icon name="play" />
+              {hhmmss(timestampedText.start_time)}
+            </Button>
+          </TimeStamp>
+        </TranscriptItem>))}
+    </TranscriptBlock>
+  );
+};
 
 const EventTranscript = ({
   transcript,
   handleSeek
 }) => {
+  // A React reference to the WindowScroller
   const windowScrollerRef = React.useRef(null);
 
+  // Stores the CellMeasurer's measurements of all transcript blocks
   const cache = new CellMeasurerCache({
+    // The width of transcript blocks are the same
     fixedWidth: true,
+    // The height of transcript blocks are variable, with the default height being 100px
     defaultHeight: 100,
   });
 
   React.useEffect(() => {
     const handleUpdateScrollPosition = () => {
       if (windowScrollerRef.current) {
+        // Need to recalculate windowScroller's scroll position from the top of page on seeing a `update-scroll-position` event.
         windowScrollerRef.current.updatePosition();
       }
     };
@@ -59,10 +109,14 @@ const EventTranscript = ({
   }, []);
 
   const onResize = () => {
+    // Need to clear all transcript blocks' measurements on document resize
     cache.clearAll();
   };
 
   const Row = ({ index, parent, key, style }) => (
+    // Row is responsible for rendering a transcript block
+    // CellMeasurer will dynamically determine the height of a transcript block,
+    // or use the cache to determine the height
     <CellMeasurer
       key={key}
       cache={cache}
@@ -71,17 +125,7 @@ const EventTranscript = ({
       rowIndex={index}
     >
       <div style={style}>
-        <TranscriptItem>
-          <TranscriptItemText>
-            {transcript[index].text}
-          </TranscriptItemText>
-          <TimeStamp>
-            <Button size="small" onClick={() => handleSeek(transcript[index].start_time)}>
-              <Icon name="play" />
-              {hhmmss(transcript[index].start_time)}
-            </Button>
-          </TimeStamp>
-        </TranscriptItem>
+        {transcriptBlockRenderer(transcript.data[index], transcript.format, handleSeek)}
       </div>
     </CellMeasurer>
   );
@@ -97,7 +141,7 @@ const EventTranscript = ({
               height={height}
               isScrolling={isScrolling}
               onScroll={onChildScroll}
-              rowCount={transcript.length}
+              rowCount={transcript.data.length}
               rowHeight={cache.rowHeight}
               rowRenderer={Row}
               scrollTop={scrollTop}

--- a/src/components/EventTranscriptSearch.jsx
+++ b/src/components/EventTranscriptSearch.jsx
@@ -45,6 +45,17 @@ const EventTranscriptSearch = ({
     cache.clearAll();
   };
 
+  const handlePlayClick = (index) => {
+    // Change video's current time to start_time
+    handleSeek(transcript[index].start_time);
+    // Dispatch custom event so that the main transcript will scroll to clicked transcript item
+    document.dispatchEvent(new CustomEvent("scroll-to-transcript-item", {
+      detail: {
+        videoTimePoint: transcript[index].start_time
+      }
+    }));
+  };
+
   const Row = ({ index, parent, key, style }) => (
     // Row is responsible for rendering a transcript item
     // CellMeasurer will dynamically determine the height of a transcript item,
@@ -66,7 +77,7 @@ const EventTranscriptSearch = ({
             />
           </TranscriptItemText>
           <TimeStamp>
-            <Button size="tiny" onClick={() => handleSeek(transcript[index].start_time)}>
+            <Button size="tiny" onClick={() => handlePlayClick(index)}>
               <Icon name="play" />
               {hhmmss(transcript[index].start_time)}
             </Button>

--- a/src/components/EventTranscriptSearch.jsx
+++ b/src/components/EventTranscriptSearch.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Button, Icon } from "semantic-ui-react";
+import { AutoSizer, CellMeasurer, CellMeasurerCache, List } from "react-virtualized";
+import Highlighter from "react-highlight-words";
+import styled from "@emotion/styled";
+import hhmmss from "../utils/hhmmss";
+
+const EventTranscriptSearch = ({
+  searchText,
+  transcript,
+  handleSeek
+}) => {
+  const cache = new CellMeasurerCache({
+    fixedWidth: true,
+    defaultHeight: 100,
+  });
+
+  const onResize = () => {
+    cache.clearAll();
+  };
+
+  const Row = ({ index, parent, key, style }) => (
+    <CellMeasurer
+      key={key}
+      cache={cache}
+      parent={parent}
+      columnIndex={0}
+      rowIndex={index}
+    >
+      <div style={style}>
+        <TranscriptItem>
+          <TimeStamp isSearch={isSearch}>
+            <Button size="tiny" onClick={() => handleSeek(transcript[index].start_time)}>
+              <Icon name="play" />
+              {hhmmss(transcript[index].start_time)}
+            </Button>
+          </TimeStamp>
+          <TranscriptItemText isSearch={isSearch}>
+            <Highlighter
+              searchWords={[searchText]}
+              autoEscape={true}
+              textToHighlight={transcript[index].text}
+            />
+          </TranscriptItemText>
+        </TranscriptItem>
+      </div>
+    </CellMeasurer>
+  );
+
+  return (
+    <AutoSizer onResize={onResize}>
+      {({ width, height }) => (
+        <List
+          deferredMeasurementCache={cache}
+          height={height}
+          rowCount={transcript.length}
+          rowHeight={cache.rowHeight}
+          rowRenderer={Row}
+          scrollToIndex={0}
+          style={{ willChange: "" }}
+          width={width}
+        />
+      )}
+    </AutoSizer>
+  );
+}
+
+export default React.memo(EventTranscriptSearch);

--- a/src/components/EventTranscriptSearch.jsx
+++ b/src/components/EventTranscriptSearch.jsx
@@ -12,6 +12,7 @@ const TranscriptItem = styled.div({
 
 const TranscriptItemText = styled.div({
   fontSize: "16px",
+  lineHeight: "1.5em"
 });
 
 const TimeStamp = styled.div({

--- a/src/components/EventTranscriptSearch.jsx
+++ b/src/components/EventTranscriptSearch.jsx
@@ -5,21 +5,49 @@ import Highlighter from "react-highlight-words";
 import styled from "@emotion/styled";
 import hhmmss from "../utils/hhmmss";
 
+const TranscriptItem = styled.div({
+  // Increase spacing around each transcript item
+  margin: "1em 0.2em"
+});
+
+const TranscriptItemText = styled.div({
+  fontSize: "16px",
+  // Increase spacing between TranscriptItemText and TimeStamp button
+  marginBottom: "0.1em"
+});
+
+const TimeStamp = styled.div({
+  ".ui.button": {
+    // Make timestamp button's padding smaller
+    padding: "0.5em !important"
+  }
+});
+
 const EventTranscriptSearch = ({
+  // The search transcript query
   searchText,
+  // The list of timestamped text that contains the searchText
   transcript,
+  // Callback to change the event video's current time to the start_time of a timestamped text
   handleSeek
 }) => {
+  // Stores the CellMeasurer's measurements of all transcript items
   const cache = new CellMeasurerCache({
+    // The width of transcript items are the same
     fixedWidth: true,
+    // The height of transcript items are variable, with the default height being 100px
     defaultHeight: 100,
   });
 
   const onResize = () => {
+    // Need to clear all transcript items' measurements on document resize
     cache.clearAll();
   };
 
   const Row = ({ index, parent, key, style }) => (
+    // Row is responsible for rendering a transcript item
+    // CellMeasurer will dynamically determine the height of a transcript item,
+    // or use the cache to determine the height
     <CellMeasurer
       key={key}
       cache={cache}
@@ -29,19 +57,19 @@ const EventTranscriptSearch = ({
     >
       <div style={style}>
         <TranscriptItem>
-          <TimeStamp isSearch={isSearch}>
-            <Button size="tiny" onClick={() => handleSeek(transcript[index].start_time)}>
-              <Icon name="play" />
-              {hhmmss(transcript[index].start_time)}
-            </Button>
-          </TimeStamp>
-          <TranscriptItemText isSearch={isSearch}>
+          <TranscriptItemText>
             <Highlighter
               searchWords={[searchText]}
               autoEscape={true}
               textToHighlight={transcript[index].text}
             />
           </TranscriptItemText>
+          <TimeStamp>
+            <Button size="small" onClick={() => handleSeek(transcript[index].start_time)}>
+              <Icon name="play" />
+              {hhmmss(transcript[index].start_time)}
+            </Button>
+          </TimeStamp>
         </TranscriptItem>
       </div>
     </CellMeasurer>

--- a/src/components/EventTranscriptSearch.jsx
+++ b/src/components/EventTranscriptSearch.jsx
@@ -45,17 +45,6 @@ const EventTranscriptSearch = ({
     cache.clearAll();
   };
 
-  const handlePlayClick = (index) => {
-    // Change video's current time to start_time
-    handleSeek(transcript[index].start_time);
-    // Dispatch custom event so that the main transcript will scroll to clicked transcript item
-    document.dispatchEvent(new CustomEvent("scroll-to-transcript-item", {
-      detail: {
-        videoTimePoint: transcript[index].start_time
-      }
-    }));
-  };
-
   const Row = ({ index, parent, key, style }) => (
     // Row is responsible for rendering a transcript item
     // CellMeasurer will dynamically determine the height of a transcript item,
@@ -77,7 +66,7 @@ const EventTranscriptSearch = ({
             />
           </TranscriptItemText>
           <TimeStamp>
-            <Button size="tiny" onClick={() => handlePlayClick(index)}>
+            <Button size="tiny" onClick={() => handleSeek(transcript[index].start_time)}>
               <Icon name="play" />
               {hhmmss(transcript[index].start_time)}
             </Button>

--- a/src/components/EventTranscriptSearch.jsx
+++ b/src/components/EventTranscriptSearch.jsx
@@ -12,14 +12,14 @@ const TranscriptItem = styled.div({
 
 const TranscriptItemText = styled.div({
   fontSize: "16px",
-  // Increase spacing between TranscriptItemText and TimeStamp button
-  marginBottom: "0.1em"
 });
 
 const TimeStamp = styled.div({
+  // Increase vertical spacing between TranscriptItemText and TimeStamp
+  marginTop: "10px",
   ".ui.button": {
     // Make timestamp button's padding smaller
-    padding: "0.5em !important"
+    padding: "0.8em !important"
   }
 });
 
@@ -65,7 +65,7 @@ const EventTranscriptSearch = ({
             />
           </TranscriptItemText>
           <TimeStamp>
-            <Button size="small" onClick={() => handleSeek(transcript[index].start_time)}>
+            <Button size="tiny" onClick={() => handleSeek(transcript[index].start_time)}>
               <Icon name="play" />
               {hhmmss(transcript[index].start_time)}
             </Button>


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
#51. And also #49, where the feature to jump to transcript portion from `videoTimePoint` was requested.
- [x] Provide context of changes.
Add UI changes to show `timestamped-speaker-turns`.
I ran into a little block trying to add the jump to transcript portion feature. Unfortunately I couldn't use that "card" UI for each speaker-turn. Instead I have a horizontal divider with `speaker` at the top of each speaker-turn. Also I used `New Speaker` for empty string speaker as requested.
Here's what it looks like:
![image](https://user-images.githubusercontent.com/37560480/71774007-094f4080-2f1c-11ea-9afe-f77fe9ca5515.png)
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
